### PR TITLE
[DPF-295] cambiando mensaje de las resoluciones

### DIFF
--- a/src/Core/Resources/assets/cms/js/components/ws_assets_images/imageSizeValidator.js
+++ b/src/Core/Resources/assets/cms/js/components/ws_assets_images/imageSizeValidator.js
@@ -7,23 +7,32 @@ function loadImage(imageSrc) {
   });
 }
 
+function sortMethod(a, b) {
+  return a < b ? 1 : -1;
+}
+
 export default async function checkImagesSizes(imageSrc, minimums) {
   try {
     const imageTag = await loadImage(imageSrc);
     const validatorData = { isValid: true };
+    const minWidth = Object
+      .values(minimums)
+      .map((m) => m.width)
+      .sort(sortMethod)
+      .shift();
+    const minHeight = Object
+      .values(minimums)
+      .map((m) => m.height)
+      .sort(sortMethod)
+      .shift();
 
-    Object.entries(minimums).forEach((min) => {
-    // The variable min is an array containing:
-    // in position 0 the ratio of the image and in position 1 the height and width of the image
-    // ex: ["16x9", {width: 1280, height: 720}]
-      if (min[1] !== undefined && min[1].height !== undefined && min[1].width !== undefined) {
-        if (imageTag.naturalHeight < min[1].height || imageTag.naturalWidth < min[1].width) {
-          validatorData.isValid = false;
-          validatorData.minHeight = min[1].height;
-          validatorData.minWidth = min[1].width;
-        }
+    if (minHeight !== undefined && minWidth !== undefined) {
+      if (imageTag.naturalHeight < minHeight || imageTag.naturalWidth < minWidth) {
+        validatorData.isValid = false;
+        validatorData.minHeight = minHeight;
+        validatorData.minWidth = minWidth;
       }
-    });
+    }
 
     return validatorData;
   } catch (err) {


### PR DESCRIPTION
Se cambia el mensaje de las resoluciones de imágenes para que se valide que la imagen cumpla con el ancho y alto de todas las resoluciones definidas.

Incidencia: [DPF-295](https://acilia.atlassian.net/browse/DPF-295)