### PR TITLE
Fix responsive table min height

### DIFF
--- a/src/Core/Resources/assets/cms/css/5-components/_components-tables.scss
+++ b/src/Core/Resources/assets/cms/css/5-components/_components-tables.scss
@@ -51,6 +51,7 @@
     position: relative;
     overflow-x: auto;
     overflow-y: hidden;
+    min-height: 550px;
 }
 
 @media (max-width: $breakpoint-mobile) {


### PR DESCRIPTION
This fixes an issuse with filter dropdowns not showing correctly on `6.2` due to the added rule `overflow-y: hidden`.

This only affects `6.2` branches.