### PR TITLE
[AE-437] gestionando que attrValue sea un iterable

### DIFF
--- a/src/Core/Resources/views/cms/form/fields.html.twig
+++ b/src/Core/Resources/views/cms/form/fields.html.twig
@@ -559,7 +559,11 @@ attr.size <= 1) -%} {% set required=false %} {%- endif -%} {% set attr=attr|merg
         {%- elseif attrvalue is same as(true) -%}
         {{- attrname }}="{{ attrname }}"
         {%- elseif attrvalue is not same as(false) -%}
+        {%- if attrvalue is iterable -%}
+        {{- attrname }}="{{ attrvalue|join(', ') }}"
+        {%- else -%}
         {{- attrname }}="{{ attrvalue }}"
+        {%- endif -%}
         {%- endif -%}
         {%- endfor -%}
         {%- endblock attributes -%}


### PR DESCRIPTION
Hay atributos del formulario como los validationsGroups que son iterables, y que cuando se configuran en los formularios, hacen que se rompa la plantilla del crud