### PR TITLE
fix-time-inputs

### DIFF
--- a/src/Core/Resources/assets/cms/css/5-components/_components-inputs.scss
+++ b/src/Core/Resources/assets/cms/css/5-components/_components-inputs.scss
@@ -150,3 +150,7 @@ input[type='file']::file-selector-button {
 input[type='file']::file-selector-button:hover {
     background: color-mix(in srgb, var(--color-success, var(--btn-background-color-primary-hover)), #ffffff 25%);
 }
+
+input[type='time'].c-input {
+    max-height: 58px;
+}


### PR DESCRIPTION
fixes height bug in time type input for safari due to injecting pseudoclasses that cannot be reset